### PR TITLE
Added `item_used_to_place` to `on_robot_built_tile` event data.

### DIFF
--- a/script/construction_drone.lua
+++ b/script/construction_drone.lua
@@ -2176,7 +2176,8 @@ surface_index :: uint: The surface the tile(s) are build on.
       }
     },
     tile = game.tile_prototypes[target_tile_name],
-    surface_index = target.surface.index
+    surface_index = target.surface.index,
+    item = drone_data.item_used_to_place
   }
   surface.set_tiles({{name = target_tile_name, position = position}}, true)
   script.raise_event(defines.events.on_robot_built_tile, event_data)


### PR DESCRIPTION
Added the item field to the event data so that mods that attempt to use item data can do so. This fixes #9.