### PR TITLE
Make search throttling configurable at runtime

### DIFF
--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -1,0 +1,5 @@
+[mod-setting-name]
+throttling=Throttling
+
+[mod-setting-description]
+throttling=CPU usage throttling. Decrease to reduce lag, increase to support larger maps.

--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -1,5 +1,5 @@
 [mod-setting-name]
-throttling=Throttling
+throttling=Job search area subdivision
 
 [mod-setting-description]
-throttling=CPU usage throttling. Decrease to reduce lag, increase to support larger maps.
+throttling=For a value N, divides the per-player search area into (N*2)^2 subdivisions. Reducing the number improves responsiveness, increasing it reduces CPU use.

--- a/script/construction_drone.lua
+++ b/script/construction_drone.lua
@@ -2253,8 +2253,6 @@ local on_runtime_mod_setting_changed = function()
   setup_search_offsets(settings.global["throttling"].value)
 end
 
-on_runtime_mod_setting_changed()
-
 local lib = {}
 
 lib.events =
@@ -2284,6 +2282,8 @@ lib.events =
 lib.on_load = function()
   data = global.construction_drone or data
   global.construction_drone = data
+
+  on_runtime_mod_setting_changed()
 end
 
 lib.on_init = function()
@@ -2296,6 +2296,7 @@ lib.on_init = function()
     player.set_shortcut_toggled("construction-drone-toggle", true)
   end
 
+  on_runtime_mod_setting_changed()
 end
 
 lib.on_configuration_changed = function()

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,10 @@
+data:extend({
+  {
+    type = "int-setting",
+    name = "throttling",
+    setting_type = "runtime-global",
+    default_value = 5,
+    minimum_value = 1,
+    maximum_value = 10
+  }
+})


### PR DESCRIPTION
This adds a configuration option to change how much work the mod does per tick.

The intent is to make it more responsive in multiplayer situations, since the search lag is multiplied by player count, but I've confirmed that *increasing* throttling also has a useful effect in reducing CPU use. I set the maximum limit to 10; anything beyond that hits strongly diminishing returns, and this already produces lag of up to five seconds in single-player.